### PR TITLE
fixed uvfits import and allowed for mis-match between sky-brightness and ms sizes

### DIFF
--- a/vis_sample/__init__.py
+++ b/vis_sample/__init__.py
@@ -3,7 +3,7 @@ This module fourier transforms a sky brightness image and then interpolates to a
 """
 
 __author__ = "Ryan Loomis"
-__version__ = "0.1"
+__version__ = "0.2"
 __email__ = "rloomis@cfa.harvard.edu"
 __status__ = "Development"
 

--- a/vis_sample/__init__.py
+++ b/vis_sample/__init__.py
@@ -8,4 +8,4 @@ __email__ = "rloomis@cfa.harvard.edu"
 __status__ = "Development"
 
 
-from vis_sampler import vis_sample
+from .vis_sampler import vis_sample

--- a/vis_sample/file_handling.py
+++ b/vis_sample/file_handling.py
@@ -28,7 +28,7 @@ def import_data_uvfits(filename):
 
     data_VV = data_real+data_imag*1.0j
 
-    return Visibility(data_VV.T, data_uu, data_vv, data_wgts, np.arange(data_VV.shape[0])*dat[1].data['ch width'][0]/1e6)
+    return Visibility(data_VV.T, data_uu, data_vv, data_wgts, np.arange(data_VV.shape[1])*dat[1].data['ch width'][0])
 
 
 # CASA interfacing code comes from Peter Williams' casa-python and casa-data package

--- a/vis_sample/file_handling.py
+++ b/vis_sample/file_handling.py
@@ -114,7 +114,7 @@ def import_data_ms(filename):
         flags = flags[:,xc]
         # if the majority of points in any channel are flagged, it probably means someone flagged an entire channel - spit warning
         if np.mean(flags.all(axis=0)) < 0.5:
-            print "WARNING: Over half of the (u,v) points in at least one channel are marked as flagged. If you didn't expect this, it is likely due to having an entire channel flagged in the ms. Please double check this and be careful if model fitting or using diff mode. Do not trust results for those channel(s), although all other unflagged channels should be fine."
+            print "WARNING: Over half of the (u,v) points in at least one channel are marked as flagged. If you didn't expect this, it is likely due to having an entire channel flagged in the ms. Please double check this and be careful if model fitting or using diff mode."
         # collapse flags to single channel, because weights are not currently channelized
         flags = flags.any(axis=0)
 
@@ -125,10 +125,11 @@ def import_data_ms(filename):
     data_VV = data_real+data_imag*1.0j
 
     # now remove all flagged data (we assume the user doesn't want to interpolate for these points)
-    data_wgts = data_wgts[np.logical_not(flags)]
-    data_uu = data_uu[np.logical_not(flags)]
-    data_vv = data_vv[np.logical_not(flags)]
-    data_VV = data_VV[:,np.logical_not(flags)]
+    # commenting this out for now, but leaving infrastructure in place if desired later
+    #data_wgts = data_wgts[np.logical_not(flags)]
+    #data_uu = data_uu[np.logical_not(flags)]
+    #data_vv = data_vv[np.logical_not(flags)]
+    #data_VV = data_VV[:,np.logical_not(flags)]
 
     return Visibility(data_VV.T, data_uu, data_vv, data_wgts, freqs)
 

--- a/vis_sample/vis_sampler.py
+++ b/vis_sample/vis_sampler.py
@@ -122,13 +122,11 @@ def vis_sample(imagefile=None, uvfile=None, uu=None, vv=None, mu_RA=0, mu_DEC=0,
         try:
             data_vis = import_data_uvfits(uvfile)
         except IOError:
-            pass
-     
-        try:
-            data_vis = import_data_ms(uvfile)
-        except RuntimeError:
-            print "Not a valid data file for interpolation. Please check that the file is a uvfits file or measurement set"
-            sys.exit(1)
+            try:
+                data_vis = import_data_ms(uvfile)
+            except RuntimeError:
+                print "Not a valid data file for interpolation. Please check that the file is a uvfits file or measurement set"
+                sys.exit(1)
 
         if verbose: 
             t1 = time.time()

--- a/vis_sample/vis_sampler.py
+++ b/vis_sample/vis_sampler.py
@@ -136,7 +136,7 @@ def vis_sample(imagefile=None, uvfile=None, uu=None, vv=None, mu_RA=0, mu_DEC=0,
             print "Data read time = " + str(t1-t0)
 
     # if we didn't catch anything, something went wrong
-    else:
+    elif uu is None or vv is None:
         print "Please supply either a uvfits file to interpolate onto (uvfile), a list of uv points (uu & vv), or a gcf_holder cache"
         return
 


### PR DESCRIPTION
uvfits import previously had a wrong factor of 1/2 for weights. also added polarization checking

previously a ms could only be output if the input sky brightness image had the same number of channels as the input ms. now if the ms is larger than the sky brightness image, the interpolated visibilities are centered and zero padded.

the infrastructure for dealing with flagged data has now been added in the background, but isn't currently used for anything (per previous discussions)