### PR TITLE
Bug fix for file_handling.py

### DIFF
--- a/vis_sample/file_handling.py
+++ b/vis_sample/file_handling.py
@@ -190,8 +190,8 @@ def import_model_fits(filename):
     mod_dec = (np.arange(npix_dec)-(mid_pix_dec-0.5))*np.abs(delt_dec)*3600
 
     # should be prepared for the case that it is a single channel image and that CRPIX3 and CDELT3 not set
-    nchan_vel = mhd['NAXIS3']
     try:
+        nchan_vel = mhd['NAXIS3']
         mid_chan_vel = mhd['CRVAL3']
         mid_chan = mhd['CRPIX3']
         delt_vel = mhd['CDELT3']


### PR DESCRIPTION
If the model fits file is single channel then it probably also won't have the NAXIS3 keyword, so I think this should also be part of 'try'.